### PR TITLE
Open README file with correct encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ RE_VERSION = r"^__version__\s*=\s*'([^']*)'$"
 
 
 def _read(path):
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding='utf8') as f:
         return f.read()
 
 


### PR DESCRIPTION
Without this fix 
python setup.py install failes

$ python setup.py install
Traceback (most recent call last):
  File "setup.py", line 32, in <module>
    long_description=_read('README.md'),
  File "setup.py", line 13, in _read
    return f.read()
  File "C:\WinPython\python-3.6.8.amd64\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 2067: character maps to <undefined>
