### PR TITLE
Create github actions configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,61 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  test:
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-18.04]
+        python-version: [2.7]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      
+      - name: Install test dependencies
+        run: |
+         pip install pyroma
+         pip install check-manifest
+         pip install twine
+         pip install wheel
+         pip list
+         
+      - name: Compile code
+        run: python -m compileall -f .
+          
+      - name: Run unit tests
+        run: test/test.py --unit --exit-early
+        
+      - name: Run integration tests
+        run: test/test.py
+        
+      - name: Check package quality
+        run: pyroma -n 9 .
+        
+      - name: Check the completeness of MANIFEST.in
+        run: check-manifest .
+        
+      - name: Check distribution
+        run: |
+          python setup.py sdist bdist_wheel
+          twine check dist/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
          pip install check-manifest
          pip install twine
          pip install wheel
+         pip install flake8
          pip list
          
       - name: Compile code
@@ -54,7 +55,11 @@ jobs:
         
       - name: Check the completeness of MANIFEST.in
         run: check-manifest .
-        
+      
+      - name: Run flake
+        continue-on-error: true
+        run: flake8 --exclude=build,venv --ignore= --max-line-length=200 --max-complexity=75 --show-source --statistics .
+          
       - name: Check distribution
         run: |
           python setup.py sdist bdist_wheel


### PR DESCRIPTION
* All test steps previously done by the travis configuration are run using the github actions CI.
* Flake is not run, because it causes errors (should be tracked in a separate issue)
* Tests are run on Ubuntu 18.04 and 20.04 (the only linux distros supported by github; others would require a self hosted runner)
* The capacity of the runners provided by github are apparently not enough for the long tests (I cancelled the execution after 30 minutes)
* The script is currently executed on all pull requests for master and for direct pushes to master.