### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci-python3-freebsd.yml
+++ b/.github/workflows/ci-python3-freebsd.yml
@@ -24,7 +24,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Test in FreeBSD
       uses: vmactions/freebsd-vm@v0.2.9

--- a/.github/workflows/ci-python3.yml
+++ b/.github/workflows/ci-python3.yml
@@ -19,8 +19,14 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-18.04 ]
+        os: [ ubuntu-22.04, ubuntu-20.04, ubuntu-18.04 ]
         python-version: [ '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        # Exclude unsupported OS/Python version combinations
+        exclude:
+          - os: ubuntu-22.04
+            python-version: '3.5'
+          - os: ubuntu-22.04
+            python-version: '3.6'
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/ci-python3.yml
+++ b/.github/workflows/ci-python3.yml
@@ -61,7 +61,7 @@ jobs:
           test/test.py -e --exit-early
 
       - name: Check package quality
-        continue-on-error: true
+        continue-on-error: ${{ contains(fromJson('["3.5", "3.6"]'), matrix.python-version) }}
         run: pyroma -n 9 .
 
       - name: Check the completeness of MANIFEST.in

--- a/.github/workflows/ci-python3.yml
+++ b/.github/workflows/ci-python3.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, ubuntu-18.04 ]
-        python-version: [ '3.5', '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11' ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/ci-python3.yml
+++ b/.github/workflows/ci-python3.yml
@@ -25,10 +25,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
* Only allow pyroma errors on Python 3.5 and 3.6
* Update versions of Github actions
* Add new Python versions 3.10 and 3.11
* Add new OS Ubuntu 22.04