### PR TITLE
Fix FreeBSD CI pipeline

### DIFF
--- a/.github/workflows/ci-python3-freebsd.yml
+++ b/.github/workflows/ci-python3-freebsd.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         release: ${{ matrix.freebsd-release }}
         usesh: true
-        prepare: pkg install -y python3 py39-pip coreutils cksfv git-tiny rust
+        prepare: pkg install -y python3 devel/py-pip coreutils cksfv git-tiny rust
         run: |
           set -ex
 

--- a/.github/workflows/ci-python3-freebsd.yml
+++ b/.github/workflows/ci-python3-freebsd.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        freebsd-release: [ '13.2', '13.3', '14.0' ]
+        freebsd-release: [ '13.3', '14.0' ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/ci-python3-freebsd.yml
+++ b/.github/workflows/ci-python3-freebsd.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        freebsd-release: [ '13.3', '14.0' ]
+        freebsd-release: [ '13.3', '14.0', '14.1' ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Currently the CI pipeline fails since FreeBSD ports switched from Python 3.9 to Python 3.11.
Use versionless pip package name to follow FreeBSD system Python version.

Also update to currently supported FreeBSD versions. Remove 13.2. Add 14.1.