### PR TITLE
Replace deprecated usages of setup.py

### DIFF
--- a/.github/workflows/ci-python3-freebsd.yml
+++ b/.github/workflows/ci-python3-freebsd.yml
@@ -61,6 +61,7 @@ jobs:
           pip install twine
           pip install wheel
           pip install flake8
+          pip install build
           pip list
 
           # Check syntax by compiling code
@@ -85,5 +86,5 @@ jobs:
           flake8 --exclude=build,venv --ignore= --max-line-length=200 --max-complexity=75 --show-source --statistics .
 
           # Check distribution
-          python setup.py sdist bdist_wheel
+          python -m build
           twine check dist/*

--- a/.github/workflows/ci-python3.yml
+++ b/.github/workflows/ci-python3.yml
@@ -51,6 +51,7 @@ jobs:
           pip install twine
           pip install wheel
           pip install flake8
+          pip install build
           pip list
 
       - name: Check syntax by compiling code
@@ -82,5 +83,5 @@ jobs:
 
       - name: Check distribution
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
           twine check dist/*

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Download a snapshot from the [Github releases page](https://github.com/cfv-proje
 or checkout the development version via Git.
 
 ```sh
-python setup.py install
+pip install .
 # optional: run tests to verify correct operation
 cd test; ./test.py
 ```


### PR DESCRIPTION
/opt/hostedtoolcache/Python/3.14.0/x64/lib/python3.14/site-packages/setuptools/_distutils/cmd.py:90: SetuptoolsDeprecationWarning: setup.py install is deprecated. !!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        By 2025-Oct-31, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()

Partially fixes #79