### PR TITLE
Add default values to arguments in benchmark.py

### DIFF
--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -159,14 +159,14 @@ def run(args):
 def main():
     parser = argparse.ArgumentParser(description='Create test data and run cfv benchmarks.')
 
-    parser.add_argument('-v', '--verbose', action='count')
+    parser.add_argument('-v', '--verbose', default=False, action='count')
 
     subparsers = parser.add_subparsers()
 
     create_parser = subparsers.add_parser('create', help='create test data hierarchy')
-    create_parser.add_argument('--files', type=human_int, help='total number of files to create')
-    create_parser.add_argument('--branch-factor', type=human_int, help='(max) number of files or directories at each level')
-    create_parser.add_argument('--max-size', type=human_int, help='max file size')
+    create_parser.add_argument('--files', default=10, type=human_int, help='total number of files to create')
+    create_parser.add_argument('--branch-factor', default=2, type=human_int, help='(max) number of files or directories at each level')
+    create_parser.add_argument('--max-size', default=1024, type=human_int, help='max file size')
     # TODO: implement hardlink (and symlink) testing
     # create_parser.add_argument('--num-links', type=human_int, help='number of hardlinks per file')
     # TODO: add option to specify filename length

--- a/test/benchmark.py
+++ b/test/benchmark.py
@@ -164,9 +164,9 @@ def main():
     subparsers = parser.add_subparsers()
 
     create_parser = subparsers.add_parser('create', help='create test data hierarchy')
-    create_parser.add_argument('--files', default=10, type=human_int, help='total number of files to create')
-    create_parser.add_argument('--branch-factor', default=2, type=human_int, help='(max) number of files or directories at each level')
-    create_parser.add_argument('--max-size', default=1024, type=human_int, help='max file size')
+    create_parser.add_argument('--files', default=256, type=human_int, help='total number of files to create')
+    create_parser.add_argument('--branch-factor', default=8, type=human_int, help='(max) number of files or directories at each level')
+    create_parser.add_argument('--max-size', default=4194304, type=human_int, help='max file size')
     # TODO: implement hardlink (and symlink) testing
     # create_parser.add_argument('--num-links', type=human_int, help='number of hardlinks per file')
     # TODO: add option to specify filename length


### PR DESCRIPTION
According to the `-h` output, all arguments for `benchmark.py create` appear to be optional:
  
 ```
  $ python3 benchmark.py create -h
  usage: benchmark.py create [-h] [--files FILES] [--branch-factor BRANCH_FACTOR] [--max-size MAX_SIZE]
  
  options:
    -h, --help            show this help message and exit
    --files FILES         total number of files to create
    --branch-factor BRANCH_FACTOR
                          (max) number of files or directories at each level
    --max-size MAX_SIZE   max file size
 ```
    
 However, when running create command without any arguments:
```
  $ python3 benchmark.py create
  Traceback (most recent call last):
    File "/home/owner/lab/cfv/test/benchmark.py", line 197, in <module>
      main()
    File "/home/owner/lab/cfv/test/benchmark.py", line 193, in main
      args.func(args)
    File "/home/owner/lab/cfv/test/benchmark.py", line 111, in create
      create_test_dir(start_path, args.files, args.branch_factor, args.max_size, verbose=args.verbose)
    File "/home/owner/lab/cfv/test/benchmark.py", line 81, in create_test_dir
      levels = int(math.ceil(math.log(num_files, branch_factor)))
  TypeError: must be real number, not NoneType
```
  
This PR adds default values to `--verbose`, `--files`, `--branch-factor`, and `--max-size` in argparse. This ensures the command can run successfully without requiring the user to provide these arguments, matching the expectation set by the help message.