### PR TITLE
Migrate to pyproject.toml

### DIFF
--- a/.github/workflows/ci-python3-freebsd.yml
+++ b/.github/workflows/ci-python3-freebsd.yml
@@ -77,7 +77,7 @@ jobs:
           su runner -c 'ulimit -n; ulimit -n 4096; test/test.py -e --exit-early'
 
           # Check package quality
-          pyroma -n 9 .
+          pyroma -n 10 .
 
           # Check the completeness of MANIFEST.in
           su runner -c 'check-manifest --ignore=Release.md .'

--- a/.github/workflows/ci-python3-freebsd.yml
+++ b/.github/workflows/ci-python3-freebsd.yml
@@ -80,7 +80,7 @@ jobs:
           pyroma -n 10 .
 
           # Check the completeness of MANIFEST.in
-          su runner -c 'check-manifest --ignore=Release.md .'
+          su runner -c 'check-manifest .'
 
           # Run flake
           flake8 --exclude=build,venv --ignore= --max-line-length=200 --max-complexity=75 --show-source --statistics .

--- a/.github/workflows/ci-python3-freebsd.yml
+++ b/.github/workflows/ci-python3-freebsd.yml
@@ -77,7 +77,7 @@ jobs:
           su runner -c 'ulimit -n; ulimit -n 4096; test/test.py -e --exit-early'
 
           # Check package quality
-          pyroma -n 7 .
+          pyroma -n 9 .
 
           # Check the completeness of MANIFEST.in
           su runner -c 'check-manifest --ignore=Release.md .'

--- a/.github/workflows/ci-python3-freebsd.yml
+++ b/.github/workflows/ci-python3-freebsd.yml
@@ -77,7 +77,7 @@ jobs:
           su runner -c 'ulimit -n; ulimit -n 4096; test/test.py -e --exit-early'
 
           # Check package quality
-          pyroma -n 10 .
+          su runner -c 'pyroma -n 10 .'
 
           # Check the completeness of MANIFEST.in
           su runner -c 'check-manifest .'

--- a/.github/workflows/ci-python3.yml
+++ b/.github/workflows/ci-python3.yml
@@ -73,6 +73,7 @@ jobs:
           test/test.py -e --exit-early
 
       - name: Check package quality
+        continue-on-error: ${{ contains(fromJson('["3.7", "3.8"]'), matrix.python-version) }}
         run: pyroma -n 10 .
 
       - name: Check the completeness of MANIFEST.in

--- a/.github/workflows/ci-python3.yml
+++ b/.github/workflows/ci-python3.yml
@@ -73,7 +73,7 @@ jobs:
           test/test.py -e --exit-early
 
       - name: Check package quality
-        run: pyroma -n 7 .
+        run: pyroma -n 9 .
 
       - name: Check the completeness of MANIFEST.in
         run: check-manifest --ignore=Release.md .

--- a/.github/workflows/ci-python3.yml
+++ b/.github/workflows/ci-python3.yml
@@ -76,7 +76,7 @@ jobs:
         run: pyroma -n 10 .
 
       - name: Check the completeness of MANIFEST.in
-        run: check-manifest --ignore=Release.md .
+        run: check-manifest .
 
       - name: Run flake
         run: flake8 --exclude=build,venv --ignore= --max-line-length=200 --max-complexity=75 --show-source --statistics .

--- a/.github/workflows/ci-python3.yml
+++ b/.github/workflows/ci-python3.yml
@@ -73,7 +73,7 @@ jobs:
           test/test.py -e --exit-early
 
       - name: Check package quality
-        run: pyroma -n 9 .
+        run: pyroma -n 10 .
 
       - name: Check the completeness of MANIFEST.in
         run: check-manifest --ignore=Release.md .

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include COPYING
 include Changelog
 include cfv.1
 include README.md
+include Release.md
 include lib/cfv/BitTorrent/LICENSE.txt
-prune Release.md
 prune debian
 prune test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "lib"}
+
+[tool.setuptools.data-files]
+"share/man/man1" = ["cfv.1"]
+
+[project]
+name = "cfv"
+description = "Command-line File Verify - versatile file checksum creator and verifier"
+readme = "README.md"
+license = "GPL-2.0-or-later AND MIT"
+license-files = ["COPYING", "lib/cfv/BitTorrent/LICENSE.txt"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Topic :: System :: Archiving",
+    "Topic :: Utilities",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
+]
+keywords = ["cfv", "checksum", "verify", "sfv", "csv", "crc", "bsdmd5", "md5sum", "sha1sum", "sha224sum", "sha256sum", "sha384sum", "sha512sum", "torrent", "par", "par2"]
+requires-python = ">=3.7"
+dynamic = ["version", "authors"]
+
+[project.urls]
+Homepage = "https://github.com/cfv-project/cfv"
+Changelog = "https://github.com/cfv-project/cfv/blob/python3/Changelog"
+"Bug Tracker" = "https://github.com/cfv-project/cfv/issues"
+"Source Code" = "https://github.com/cfv-project/cfv"
+"Original Project" = "http://cfv.sourceforge.net/"
+
+[project.scripts]
+cfv = "cfv.common:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ package-dir = {"" = "lib"}
 name = "cfv"
 description = "Command-line File Verify - versatile file checksum creator and verifier"
 readme = "README.md"
-license-files = ["COPYING", "lib/cfv/BitTorrent/LICENSE.txt"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ package-dir = {"" = "lib"}
 name = "cfv"
 description = "Command-line File Verify - versatile file checksum creator and verifier"
 readme = "README.md"
-license = "GPL-2.0-or-later AND MIT"
 license-files = ["COPYING", "lib/cfv/BitTorrent/LICENSE.txt"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -32,7 +31,7 @@ classifiers = [
 ]
 keywords = ["cfv", "checksum", "verify", "sfv", "csv", "crc", "bsdmd5", "md5sum", "sha1sum", "sha224sum", "sha256sum", "sha384sum", "sha512sum", "torrent", "par", "par2"]
 requires-python = ">=3.7"
-dynamic = ["version", "authors"]
+dynamic = ["version", "authors", "license"]
 
 [project.urls]
 Homepage = "https://github.com/cfv-project/cfv"

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
-#! /usr/bin/env python
-
 import re
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 
 RE_VERSION = r"^__version__\s*=\s*'([^']*)'$"
@@ -26,45 +24,7 @@ def _get_version(path):
 version = _get_version('lib/cfv/common.py')
 
 setup(
-    name='cfv',
     version=version,
-    description='Command-line File Verify - versatile file checksum creator and verifier',
-    long_description=_read('README.md'),
-    long_description_content_type='text/markdown',
-    url='https://github.com/cfv-project/cfv',
     author='Lisa Gnedt (Current Maintainer)',
     author_email='%s@%s' % ('cfv-project', 'davizone.at'),
-    license='GPL-2.0-or-later',
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Console',
-        'Topic :: System :: Archiving',
-        'Topic :: Utilities',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
-        'Programming Language :: Python :: 3.14',
-        'Programming Language :: Python :: 3.15',
-    ],
-    keywords='cfv checksum verify sfv csv crc bsdmd5 md5sum sha1sum sha224sum sha256sum sha384sum sha512sum torrent par par2',
-    project_urls={
-        'Bug Tracker': 'https://github.com/cfv-project/cfv/issues',
-        'Source Code': 'https://github.com/cfv-project/cfv',
-        'Original Project': 'http://cfv.sourceforge.net/',
-    },
-    python_requires='>=3.7',
-    packages=find_packages('lib'),
-    package_dir={'': 'lib'},
-    include_package_data=True,
-    data_files=[('share/man/man1', ['cfv.1'])],
-    entry_points={
-        'console_scripts': [
-            'cfv=cfv.common:main',
-        ],
-    },
 )

--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,5 @@ setup(
     # backward compatibility issues with older setuptools versions.
     # See: https://github.com/pypa/setuptools/issues/4903
     license_expression='GPL-2.0-or-later AND MIT',
+    license_files=('COPYING', 'lib/cfv/BitTorrent/LICENSE.txt'),
 )

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,10 @@ setup(
     version=version,
     author='Lisa Gnedt (Current Maintainer)',
     author_email='%s@%s' % ('cfv-project', 'davizone.at'),
-    # license_expression is defined here and not in pyproject.toml due to
-    # backward compatibility issues with older setuptools versions.
+    # license and license_expression is defined here and not in pyproject.toml
+    # due to backward compatibility issues with older setuptools versions.
     # See: https://github.com/pypa/setuptools/issues/4903
+    license='GPL-2.0-or-later AND MIT',
     license_expression='GPL-2.0-or-later AND MIT',
     license_files=('COPYING', 'lib/cfv/BitTorrent/LICENSE.txt'),
 )

--- a/setup.py
+++ b/setup.py
@@ -27,4 +27,8 @@ setup(
     version=version,
     author='Lisa Gnedt (Current Maintainer)',
     author_email='%s@%s' % ('cfv-project', 'davizone.at'),
+    # license_expression is defined here and not in pyproject.toml due to
+    # backward compatibility issues with older setuptools versions.
+    # See: https://github.com/pypa/setuptools/issues/4903
+    license_expression='GPL-2.0-or-later AND MIT',
 )


### PR DESCRIPTION
Migrate as much as possible from setup.py to pyproject.toml.
This fixes the following warning from pyroma:

```
Your project does not have a pyproject.toml file, which is highly recommended.
You probably want to create one with the following configuration:

    [build-system]
    requires = ["setuptools>=42"]
    build-backend = "setuptools.build_meta"
```

Fixes https://github.com/cfv-project/cfv/issues/79