### PR TITLE
Fix error handling during type autodetection in create mode

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 2025-xx-xx - v3.2.1.dev0:
 	* WARNING: This is a development snapshot, not a stable release.
+	* Fix error handling during type autodetection in create mode.
 
 2025-11-02 - v3.2.0:
 	* Drop support for Python 3.6.

--- a/lib/cfv/common.py
+++ b/lib/cfv/common.py
@@ -2215,7 +2215,8 @@ def main(argv=None):
                         testa = a[:-3]
                     cftype = cftypes.auto_filename_match(a, testa)
                     if not cftype:
-                        raise CFVValueError('specify a filetype with -t, or use standard extension')
+                        view.perror('cfv: specify a filetype with -t, or use standard extension')
+                        sys.exit(1)
                     make(cftype, a, args)
 
     if mode == 0:


### PR DESCRIPTION
When specifying an unknown filename without type in create mode the exception is not handled correctly:

```
$ cfv -C -f asdf
Traceback (most recent call last):
  File "/persist/cfv/test/cfv", line 9, in <module>
    cfv.common.main()
    ~~~~~~~~~~~~~~~^^
  File "/persist/cfv/lib/cfv/common.py", line 2314, in main
    raise CFVValueError('specify a filetype with -t, or use standard extension')
cfv.exceptions.CFVValueError: specify a filetype with -t, or use standard extension
```

This fix handles and displays the error correctly:

```
$ cfv -C -f asdf
cfv: specify a filetype with -t, or use standard extension
```